### PR TITLE
Sprint 3 - Code with Logging for GET events all/by id

### DIFF
--- a/lambda/getEventById.js
+++ b/lambda/getEventById.js
@@ -1,0 +1,105 @@
+
+/*
+*  Zak Brinlee
+*  AD 440 - ActoKids practicum
+*  Sprint 3 task - Logging relevant data from GET event by id function
+*  This Lambda function is currently on my personal AWS account
+*/
+
+// aws-sdk is used for accessing aws services through libraries 
+const AWS = require('aws-sdk');
+
+// Lambda function to handle GET requests for specific Events in the ActoKids DynamoDB events table by the event_id key.
+// This function will need to have the handling for PUT and DELETE requests during later sprints
+
+// handler object created by Lambda and serves as the entry point that AWS Lambda uses to execute your function code. 
+// event is the header and parameters from the request
+exports.handler = async (event, context) => {
+    
+    // Console log to CloudWatch for Lambda function start
+    console.log("ak-api-zak-lambda GET event by event_id function started.");
+    
+    // Insantiate new instance of DynamoDB object with specified api version. 
+    const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
+    
+    // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
+    const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-west-2'});
+
+    // responseBody variable to capture the response from DynamoDB for return message
+    let responseBody = '';
+    
+    // statusCode variable to capture the statusCode as result of DynamoDB action (i.e. 404, 500 )
+    let statusCode = 0;
+    
+    // eventId variable to capture the specific event id coming from the path parameters in the http request
+    let eventId = event.pathParameters.id;
+    
+    // Console log to CloudWatch for the event id provided in the path parameters.
+    console.log("Path parameter, event_id: ", eventId);
+   
+    // parameters for DynamoDB request. 
+    const params = {
+        TableName: 'sprint2_testTable',
+        KeyConditionExpression: "#event_id = :event_id",
+        // Specify which attribute to search for
+        ExpressionAttributeNames:{
+            "#event_id": "event_id"
+        },
+        // Specify which attribute value {event id} to search for
+        ExpressionAttributeValues: {
+            ":event_id": eventId
+        },
+        // ProjectionExpression is for the request attributes of events in table 
+        ProjectionExpression: "event_id, user_name, activity_type, description, organization_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, show_status, approver"
+    }//end of params
+
+    
+    try {
+        // Creating variable {data} to store the response from DynamoDB using the params created above
+        // documentClient.query() will search the entire table based on the parameters given.
+        const data = await documentClient.query(params).promise();
+        responseBody = data;
+
+        // Checking if the query returned with an event or found no matches
+        if(responseBody.Count == 0) {
+            //setting responseBody and statusCode on no results returned from DynamoDB
+            responseBody = 'Event not found';
+            statusCode = 404;
+            
+            // Log for no event found
+            console.log("Query did not find a matching event with the event_id provided. Status code: ", statusCode);
+        } else {
+            //setting responseBody and statusCode on successful return of event from DynamoDB
+            responseBody = JSON.stringify(responseBody.Items);
+            statusCode = 200;
+            
+            // Log for event found
+            console.log("Event found, status code: ", statusCode);
+        }
+        
+    } catch(err) {
+        responseBody = 'Failure to connect or retrieve from the database';
+        statusCode = 500;
+        
+        // Log for error with DynamoDB query
+        console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
+        console.error("Error: " + err);
+    }//end of catch
+
+    // Create response to return with statusCode, headers, and responseBody. 
+    const response = {
+        statusCode: statusCode,
+        headers : {
+            "Access-Control-Allow-Origin" : "*"
+        },
+        body: responseBody
+    };
+
+    // Console log to CloudWatch for response returned by Lambda function
+    console.log("Response being returned by Lambda: ", response);
+
+    // Console log to CloudWatch for Lambda function ending
+    console.log("ak-api-zak-lambda lambda GET event by event_id function ended.");
+    
+    return response;
+}//end of exports.handler

--- a/lambda/getEvents.js
+++ b/lambda/getEvents.js
@@ -1,0 +1,78 @@
+
+/*
+*  Zak Brinlee
+*  AD 440 - ActoKids practicum
+*  Sprint 3 task - Logging relevant data from GET function
+*  This Lambda function is currently on the AWS school account
+*/
+
+// aws-sdk is used for accessing aws services through libraries 
+const AWS = require('aws-sdk');
+
+// Lambda function to handle GET requests for all Events in the ActoKids DynamoDB events table.
+// handler object created by Lambda and serves as the entry point that AWS Lambda uses to execute your function code. 
+// event is the header and parameters from the request
+exports.handler = async (event, context) => {
+    
+    // Console log to CloudWatch for Lambda function start
+    console.log("ak-api-zak-lambda function started.");
+    
+    // Instantiate new instance of DynamoDB object with specified api version. 
+    const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
+    
+    // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
+    const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-east-2'});
+    
+    // responseBody variable to capture the response from DynamoDB for return message
+    let responseBody = '';
+    
+    // statusCode variable to capture the statusCode as result of DynamoDB action (i.e. 404, 500 )
+    let statusCode = 0;
+    
+    // parameters for DynamoDB request. 
+    // ProjectionExpression is for the request attributes of events in table 
+    const params = {
+        TableName: 'ak-api-zak-dynamodb',
+        ProjectionExpression: "event_id, user_name, activity_type, description, org_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, event_status, approver, created_timestamp, event_link, event_name"
+    }//end of params
+
+    
+    try {
+        // Creating variable {data} to store the response from DynamoDB using the params created above
+        // documentClient.scan() Returns one or more items and item attributes by accessing every item in a table.
+        const data = await documentClient.scan(params).promise();
+        
+        //setting responseBody and statusCode on successful return from DynamoDB
+        responseBody = JSON.stringify(data); 
+        statusCode = 200;
+        
+        // Log for successful DynamoDB scan
+        console.log("Successful scan. Status code: " + statusCode)
+    } catch(err) {
+        //setting responseBody and statusCode on successful return from DynamoDB
+        responseBody = 'Unable to connect to database';
+        statusCode = 500;
+        
+        // Log for error with DynamoDB scan
+        console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
+        console.error("Error: " + err);
+    }//end of catch
+
+    // Create response to return with statusCode, headers, and responseBody. 
+    const response = {
+        statusCode: statusCode,
+        headers : {
+            "Access-Control-Allow-Origin" : "*"
+        },
+        body: responseBody
+    };
+    
+    // Console log to CloudWatch for Lambda response
+    console.log("Response being returned by Lambda: ", response);
+    
+    // Console log to CloudWatch for Lambda function ending
+    console.log("ak-api-zak-lambda function ended.");
+    
+    return response;
+}//end of exports.handler
+


### PR DESCRIPTION
This pull-request is for Issue #15. 

For additional information review [wiki](https://github.com/ActoKids/api/wiki/Logging-for-GET-requests).

**NOTE: To be able to see CloudWatch Logs if you don't have CloudWatch permissions**
1. Go to Lambda Management Console in the AD 440 AWS account
2. Select ak-api-zak-lambda Function from the list
3. Top right corner - make sure zakSprint3GETAllEvents test is selected
4. Run the test - Expand Execution Result pane
5. Review CloudWatch code logs from the Log Output section at the bottom.  

Testing:
GET all events (school AWS account):
 `curl -v https://91i4hx5677.execute-api.us-east-2.amazonaws.com/Sprint3/v1/events`

GET event by id (personal AWS account):
 `curl -v https://8cex032b53.execute-api.us-west-2.amazonaws.com/sprint2_test/v1/events/1`