### PR TITLE
Updated delete lambda to have event_id for the pk in dynamodb.

### DIFF
--- a/travis-sprint3/events/index.js
+++ b/travis-sprint3/events/index.js
@@ -2,95 +2,95 @@
 const AWS = require('aws-sdk');
 // the DynamoDB.DocumentClient class allows access to Dynamodb directly 
 // region must be us-east-2 for Ohio
-const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-east-2'}); 
-	
+const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-east-2' });
+
 // this package is needed to validate parameters that are uuids
 const validate = require('uuid-validate');
 
 // lambda function that deletes an ak-api-travis-dynamodb (Events) db item by a given primary key
 // it will need to handle PUT requests and GET in later sprints
 exports.handler = async (event, context) => {
-    // log for when lambda function starts
-    console.log("ak-api-travis-lambda lambda function started...");
-    
-    // this stores the input given by the caller, a UUID (uuid v1) for a specific item in the ak-api-travis-dynamodb table
-    const ID = event.pathParameters.eventID;
-    
-    // log for recording the given url parameter given
-    console.log("Path parameter, eventID: ", ID);
-    
+	// log for when lambda function starts
+	console.log("ak-api-travis-lambda lambda function started...");
+
+	// this stores the input given by the caller, a UUID (uuid v1) for a specific item in the ak-api-travis-dynamodb table
+	const ID = event.pathParameters.eventID;
+
+	// log for recording the given url parameter given
+	console.log("Path parameter, eventID: ", ID);
+
 	// this stores the http method used by the caller and is needed when determining whether the call is a 
 	// DELETE, PUT, or GET request
-    const httpMethod = event.httpMethod;
-    
-    // validate input parameter as uuid version 1, when fails a 400 response must be given
-    if(!validate(ID, 1)) {
-    	var response = {
-		    statusCode: 400,
-		    headers: {
-		        "Access-Control-Allow-Origin": "*"
-		    },
-		 }
-		 return response;
-    }
+	const httpMethod = event.httpMethod;
+
+	// validate input parameter as uuid version 1, when fails a 400 response must be given
+	if (!validate(ID, 1)) {
+		var response = {
+			statusCode: 400,
+			headers: {
+				"Access-Control-Allow-Origin": "*"
+			},
+		}
+		return response;
+	}
 
 
-   // determine what http request is made to handle it appropriately 
-   // *** only using DELETE now but will need the others soon
-   if (httpMethod === 'DELETE') {
-   	
+	// determine what http request is made to handle it appropriately 
+	// *** only using DELETE now but will need the others soon
+	if (httpMethod === 'DELETE') {
+
 		// params contains the table name and primary key to delete an item with the given url parameter
-	    var params = {
-	        TableName : "ak-api-travis-dynamodb",
-	        Key : {
-				"eventID" : ID
+		var params = {
+			TableName: "ak-api-travis-dynamodb",
+			Key: {
+				"event_id": ID
 			},
 			// needed to return deleted item or empty object if nothing found to delete by given ID
-	        "ReturnValues": "ALL_OLD"
+			"ReturnValues": "ALL_OLD"
 		};
-		
+
 		let code;
 		try {
 			// delete method is needed to delete items from a Dynamodb table
-		    const data = await documentClient.delete(params).promise();
-		    
-		    // check if nothing was returned to cause a 404 response, item not found in db 
-		    if(Object.entries(data).length === 0 && data.constructor === Object) {
-		    	code = 404;
-		    	// log needed for when a parameter eventID is not found in the db
-		    	console.log(`eventID ${ID} not found in Table.`);
-		    }
-		    else {
-		    	code = 200;
-		    	// log needed to confirm successful deletion of item in db
-		    	console.log("Item successfully deleted.");
-		    }
-			 
-		} catch(err) {
+			const data = await documentClient.delete(params).promise();
+
+			// check if nothing was returned to cause a 404 response, item not found in db 
+			if (Object.entries(data).length === 0 && data.constructor === Object) {
+				code = 404;
+				// log needed for when a parameter eventID is not found in the db
+				console.log(`eventID ${ID} not found in Table.`);
+			}
+			else {
+				code = 200;
+				// log needed to confirm successful deletion of item in db
+				console.log("Item successfully deleted.");
+			}
+
+		} catch (err) {
 			code = 500;
 			// error log needed to record internal server errors
 			console.error("Internal Server Error: ", err);
 		}
-		
+
 		// if you want a mesage for humans add body after headers
 		var response = {
 			statusCode: code,
 			headers: {
-			    "Access-Control-Allow-Origin": "*"
+				"Access-Control-Allow-Origin": "*"
 			},
-	    }
-		
-		
-	    return response;
-		
-   } else if (httpMethod === 'GET') {
-      // not used in this sprint
-   } else if (httpMethod === 'PUT') {
-      // not used in this sprint
-   }
- 
-   // log for when lambda function ends
-    console.log("ak-api-travis-lambda lambda function ended.");
+		}
+
+
+		return response;
+
+	} else if (httpMethod === 'GET') {
+		// not used in this sprint
+	} else if (httpMethod === 'PUT') {
+		// not used in this sprint
+	}
+
+	// log for when lambda function ends
+	console.log("ak-api-travis-lambda lambda function ended.");
 };
 
 


### PR DESCRIPTION
This is for the bug at https://github.com/ActoKids/api/issues/31 which I closed upon updating.  In short I had the wrong primary key for dynamodb.  I used eventID instead of event_id.  This is now fixed in both dynamodb table ak-api-travis-dynamodb and lambda function ak-api-travis-lambda.

**CURL DEMO:**

- This call results in a 200 response and deletes the item (TEST EACH ONLY ONCE):
`curl -v -H "Content-Type:application/json" -X DELETE https://s0fwtr81ia.execute-api.us-east-2.amazonaws.com/v1/events/3e0ef29c-3248-11e9-b210-d663bd873d93`
and
`curl -v -H "Content-Type:application/json" -X DELETE https://s0fwtr81ia.execute-api.us-east-2.amazonaws.com/v1/events/4d413004-403a-11e9-b210-d663bd873d93`

- This call results in a 404 response for an item not found:
`curl -v -H "Content-Type:application/json" -X DELETE https://s0fwtr81ia.execute-api.us-east-2.amazonaws.com/v1/events/57c6ba76-3469-11e9-b210-d663bd873d93`

- This call results in a 400 response for invalid input (not uuid version 1):
`curl -v -H "Content-Type:application/json" -X DELETE https://s0fwtr81ia.execute-api.us-east-2.amazonaws.com/v1/events/4`