### PR TITLE
Sprint5 fixes, inplementing is-uuid library

### DIFF
--- a/lambda/events/get/index.js
+++ b/lambda/events/get/index.js
@@ -1,78 +1,84 @@
-
 /*
 *  Zak Brinlee
 *  AD 440 - ActoKids practicum
-*  Sprint 3 task - Logging relevant data from GET function
-*  This Lambda function is currently on the AWS school account
+*  Sprint 5 task - Fix GET all events and prep for prod demo
 */
 
-// aws-sdk is used for accessing aws services through libraries 
+// aws-sdk is used for accessing aws services through libraries
 const AWS = require('aws-sdk');
 
 // Lambda function to handle GET requests for all Events in the ActoKids DynamoDB events table.
-// handler object created by Lambda and serves as the entry point that AWS Lambda uses to execute your function code. 
+// handler object created by Lambda and serves as the entry point that AWS Lambda uses to execute your function code.
 // event is the header and parameters from the request
-exports.handler = async (event, context) => {
-    
-    // Console log to CloudWatch for Lambda function start
-    console.log("ak-api-zak-lambda function started.");
-    
-    // Instantiate new instance of DynamoDB object with specified api version. 
-    const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
-    
-    // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
-    const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-east-2'});
-    
-    // responseBody variable to capture the response from DynamoDB for return message
-    let responseBody = '';
-    
-    // statusCode variable to capture the statusCode as result of DynamoDB action (i.e. 404, 500 )
-    let statusCode = 0;
-    
-    // parameters for DynamoDB request. 
-    // ProjectionExpression is for the request attributes of events in table 
-    const params = {
-        TableName: 'ak-api-zak-dynamodb',
-        ProjectionExpression: "event_id, user_name, activity_type, description, org_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, event_status, approver, created_timestamp, event_link, event_name"
-    }//end of params
+exports.handler = async (event, context, callback) => {
+  
+   // Console log to CloudWatch for Lambda function start
+   console.log("ActoKids GET all events function started.");
+  
+   // Instantiate new instance of DynamoDB object with specified api version.
+   const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
+  
+   // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
+   const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-west-2'});
+  
+   // responseBody variable to capture the response from DynamoDB for return message
+   let responseBody = '';
+  
+   // statusCode variable to capture the statusCode as result of DynamoDB action (i.e. 404, 500 )
+   let statusCode = 0;
 
-    
-    try {
-        // Creating variable {data} to store the response from DynamoDB using the params created above
-        // documentClient.scan() Returns one or more items and item attributes by accessing every item in a table.
-        const data = await documentClient.scan(params).promise();
-        
-        //setting responseBody and statusCode on successful return from DynamoDB
-        responseBody = JSON.stringify(data); 
-        statusCode = 200;
-        
-        // Log for successful DynamoDB scan
-        console.log("Successful scan. Status code: " + statusCode)
-    } catch(err) {
-        //setting responseBody and statusCode on successful return from DynamoDB
-        responseBody = 'Unable to connect to database';
-        statusCode = 500;
-        
-        // Log for error with DynamoDB scan
-        console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
-        console.error("Error: " + err);
-    }//end of catch
+   // Log calling API type and endpoint
+   console.log("API endpoint called: " + event.context['http-method'] + " " + event.context['resource-path']);
 
-    // Create response to return with statusCode, headers, and responseBody. 
-    const response = {
-        statusCode: statusCode,
-        headers : {
-            "Access-Control-Allow-Origin" : "*"
-        },
-        body: responseBody
-    };
-    
-    // Console log to CloudWatch for Lambda response
-    console.log("Response being returned by Lambda: ", response);
-    
-    // Console log to CloudWatch for Lambda function ending
-    console.log("ak-api-zak-lambda function ended.");
-    
-    return response;
+   // Log calling API type and endpoint
+   console.log("Calling from IP: " + event.params.header['X-Forwarded-For']);
+  
+   // parameters for DynamoDB request.
+   // ProjectionExpression is for the request attributes of events in table
+   const params = {
+       TableName: 'ak-prod-events-dynamo',
+       ProjectionExpression: "event_id, user_name, activity_type, description, org_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, event_status, approver, created_timestamp, event_link, event_name"
+   }//end of params
+
+  
+   try {
+       // Creating variable {data} to store the response from DynamoDB using the params created above
+       // documentClient.scan() Returns one or more items and item attributes by accessing every item in a table.
+       const data = await documentClient.scan(params).promise();
+      
+       //setting responseBody and statusCode on successful return from DynamoDB
+       responseBody = data;
+       statusCode = 200;
+      
+       // Log for successful DynamoDB scan
+       console.log("Successful scan. Status code: " + statusCode)
+
+       callback(null, responseBody);
+   } catch(err) {
+       //setting responseBody and statusCode on successful return from DynamoDB
+       responseBody = 'Unable to connect to database';
+       statusCode = 500;
+      
+       // Log for error with DynamoDB scan
+       console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
+       console.error("Error: " + err);
+  
+       callback(JSON.stringify(responseBody), null)
+   }//end of catch
+
+   // Create response to return with statusCode, headers, and responseBody.
+   const response = {
+       statusCode: statusCode,
+       headers : {
+           "Access-Control-Allow-Origin" : "*"
+       },
+       body: responseBody
+   };
+  
+   // Console log to CloudWatch for Lambda response
+   console.log("Response being returned by Lambda: ", response);
+  
+   // Console log to CloudWatch for Lambda function ending
+   console.log("ActoKids GET all events function ended.");
+  
 }//end of exports.handler
-

--- a/lambda/events/get/index.js
+++ b/lambda/events/get/index.js
@@ -27,14 +27,13 @@ exports.handler = async (event, context, callback) => {
    // Log calling API type and endpoint
    console.log("API endpoint called: " + event.context['http-method'] + " " + event.context['resource-path']);
 
-   // Log calling API type and endpoint
+   // Log for the calling IP address
    console.log("Calling from IP: " + event.params.header['X-Forwarded-For']);
   
    // parameters for DynamoDB request.
    // ProjectionExpression is for the request attributes of events in table
    const params = {
        TableName: 'ak-prod-events-dynamo',
-       ProjectionExpression: "event_id, user_name, activity_type, description, org_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, event_status, approver, created_timestamp, event_link, event_name"
    }//end of params
 
   

--- a/lambda/events/get/index.js
+++ b/lambda/events/get/index.js
@@ -14,10 +14,7 @@ exports.handler = async (event, context, callback) => {
   
    // Console log to CloudWatch for Lambda function start
    console.log("ActoKids GET all events function started.");
-  
-   // Instantiate new instance of DynamoDB object with specified api version.
-   const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
-  
+    
    // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
    const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-west-2'});
   
@@ -63,15 +60,12 @@ exports.handler = async (event, context, callback) => {
        console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
        console.error("Error: " + err);
   
-       callback(JSON.stringify(responseBody), null)
+       callback(JSON.stringify(err), null)
    }//end of catch
 
-   // Create response to return with statusCode, headers, and responseBody.
+   // Create response to return with statusCode and responseBody.
    const response = {
        statusCode: statusCode,
-       headers : {
-           "Access-Control-Allow-Origin" : "*"
-       },
        body: responseBody
    };
   

--- a/lambda/events_id/get/index.js
+++ b/lambda/events_id/get/index.js
@@ -20,9 +20,6 @@ exports.handler = async (event, context, callback) => {
     // Console log to CloudWatch for Lambda function start
     console.log("ActoKids GET event by event_id function started.");
     
-    // Insantiate new instance of DynamoDB object with specified api version. 
-    const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
-    
     // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
     const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-west-2'});
 
@@ -51,9 +48,6 @@ exports.handler = async (event, context, callback) => {
     // Create response to return with statusCode, headers, and responseBody. 
     const response = {
         statusCode: statusCode,
-        headers : {
-            "Access-Control-Allow-Origin" : "*"
-        },
         body: body
     };
     

--- a/lambda/events_id/get/index.js
+++ b/lambda/events_id/get/index.js
@@ -72,8 +72,6 @@ exports.handler = async (event, context, callback) => {
             ExpressionAttributeValues: {
                 ":event_id": eventId
             },
-            // ProjectionExpression is for the request attributes of events in table 
-            ProjectionExpression: "event_id, user_name, activity_type, description, organization_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, show_status, approver"
         }//end of params
     
         try {

--- a/lambda/events_id/get/index.js
+++ b/lambda/events_id/get/index.js
@@ -2,22 +2,23 @@
 /*
 *  Zak Brinlee
 *  AD 440 - ActoKids practicum
-*  Sprint 3 task - Logging relevant data from GET event by id function
-*  This Lambda function is currently on my personal AWS account
+*  Sprint 5 task - Fix GET by event_id and prep for prod demo
 */
 
 // aws-sdk is used for accessing aws services through libraries 
 const AWS = require('aws-sdk');
 
 // Lambda function to handle GET requests for specific Events in the ActoKids DynamoDB events table by the event_id key.
-// This function will need to have the handling for PUT and DELETE requests during later sprints
+
+// this package is needed to validate parameters that are uuids
+const isUUID = require('is-uuid');
 
 // handler object created by Lambda and serves as the entry point that AWS Lambda uses to execute your function code. 
 // event is the header and parameters from the request
-exports.handler = async (event, context) => {
+exports.handler = async (event, context, callback) => {
     
     // Console log to CloudWatch for Lambda function start
-    console.log("ak-api-zak-lambda GET event by event_id function started.");
+    console.log("ActoKids GET event by event_id function started.");
     
     // Insantiate new instance of DynamoDB object with specified api version. 
     const db = new AWS.DynamoDB({ apiVersion: '2012-10-08'});
@@ -25,66 +26,27 @@ exports.handler = async (event, context) => {
     // DynamoDB.DocumentClient is a helper class for accessing DynamoDB with Javascript
     const documentClient = new AWS.DynamoDB.DocumentClient({ region: 'us-west-2'});
 
-    // responseBody variable to capture the response from DynamoDB for return message
-    let responseBody = '';
+    // body variable to capture the response from DynamoDB for return message
+    let body = 'Unknown Error - Invalid ID';
     
     // statusCode variable to capture the statusCode as result of DynamoDB action (i.e. 404, 500 )
     let statusCode = 0;
-    
+
     // eventId variable to capture the specific event id coming from the path parameters in the http request
-    let eventId = event.pathParameters.id;
+    const eventId = event.params.path['event_id'];
     
     // Console log to CloudWatch for the event id provided in the path parameters.
     console.log("Path parameter, event_id: ", eventId);
-   
-    // parameters for DynamoDB request. 
-    const params = {
-        TableName: 'sprint2_testTable',
-        KeyConditionExpression: "#event_id = :event_id",
-        // Specify which attribute to search for
-        ExpressionAttributeNames:{
-            "#event_id": "event_id"
-        },
-        // Specify which attribute value {event id} to search for
-        ExpressionAttributeValues: {
-            ":event_id": eventId
-        },
-        // ProjectionExpression is for the request attributes of events in table 
-        ProjectionExpression: "event_id, user_name, activity_type, description, organization_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, show_status, approver"
-    }//end of params
 
+    // this stores the http method used by the caller
+    //const httpMethod = event.httpMethod;
+    const httpMethod = event.context['http-method'];
     
-    try {
-        // Creating variable {data} to store the response from DynamoDB using the params created above
-        // documentClient.query() will search the entire table based on the parameters given.
-        const data = await documentClient.query(params).promise();
-        responseBody = data;
-
-        // Checking if the query returned with an event or found no matches
-        if(responseBody.Count == 0) {
-            //setting responseBody and statusCode on no results returned from DynamoDB
-            responseBody = 'Event not found';
-            statusCode = 404;
-            
-            // Log for no event found
-            console.log("Query did not find a matching event with the event_id provided. Status code: ", statusCode);
-        } else {
-            //setting responseBody and statusCode on successful return of event from DynamoDB
-            responseBody = JSON.stringify(responseBody.Items);
-            statusCode = 200;
-            
-            // Log for event found
-            console.log("Event found, status code: ", statusCode);
-        }
-        
-    } catch(err) {
-        responseBody = 'Failure to connect or retrieve from the database';
-        statusCode = 500;
-        
-        // Log for error with DynamoDB query
-        console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
-        console.error("Error: " + err);
-    }//end of catch
+    //Log calling API type and endpoint
+    console.log("API-Endpoint called: " + httpMethod + " " + event.context['resource-path']);
+    
+    //Log calling IP
+    console.log("Calling-IP: " + event.params.header['X-Forwarded-For']);
 
     // Create response to return with statusCode, headers, and responseBody. 
     const response = {
@@ -92,14 +54,75 @@ exports.handler = async (event, context) => {
         headers : {
             "Access-Control-Allow-Origin" : "*"
         },
-        body: responseBody
+        body: body
     };
+    
+    // validate input parameter as uuid version 5, when fails a 400 response must be given
+    if(!isUUID.anyNonNil(eventId)) {
+    	console.log("ERROR: uuid in not uuid/v4");
+    	response.statusCode = 400;
+		callback(JSON.stringify(response), null);
+	
+    }
+    else {
+
+        // parameters for DynamoDB request. 
+        const params = {
+            TableName: 'ak-prod-events-dynamo',
+            KeyConditionExpression: "#event_id = :event_id",
+            // Specify which attribute to search for
+            ExpressionAttributeNames:{
+                "#event_id": "event_id"
+            },
+            // Specify which attribute value {event id} to search for
+            ExpressionAttributeValues: {
+                ":event_id": eventId
+            },
+            // ProjectionExpression is for the request attributes of events in table 
+            ProjectionExpression: "event_id, user_name, activity_type, description, organization_name, location_name, location_address, contact_name, contact_phone, contact_email, start_date_time, end_date_time, frequency, cost, picture_url, min_age, max_age, disability_types, show_status, approver"
+        }//end of params
+    
+        try {
+            // Creating variable {data} to store the response from DynamoDB using the params created above
+            // documentClient.query() will search the entire table based on the parameters given.
+            const data = await documentClient.query(params).promise();
+            response.body = data;
+            console.log(JSON.stringify(response));
+            // Checking if the query returned with an event or found no matches
+            if(response.body.Count == 0) {
+                //setting responseBody and statusCode on no results returned from DynamoDB
+                response.Body = 'Event not found';
+                response.statusCode = 404;
+            
+                callback(response, null)
+                // Log for no event found
+                console.log("Query did not find a matching event with the event_id provided. Status code: ", statusCode);
+            } else {
+                //setting responseBody and statusCode on successful return of event from DynamoDB
+                response.body = response.body.Items;
+                response.statusCode = 200;
+                
+                callback(null, response.body)
+                // Log for event found
+                console.log("Event found, status code: ", statusCode);
+            }
+            
+        } catch(err) {
+            response.body = 'Failure to connect or retrieve from the database';
+            response.statusCode = 500;
+            
+            // Log for error with DynamoDB query
+            console.error("Unsuccessful connection to DynamoDB. Status code: " + statusCode);
+            console.error("Error: " + err);
+            callback(JSON.stringify(response), null)
+        }//end of catch
+    }
+
 
     // Console log to CloudWatch for response returned by Lambda function
     console.log("Response being returned by Lambda: ", response);
 
     // Console log to CloudWatch for Lambda function ending
-    console.log("ak-api-zak-lambda lambda GET event by event_id function ended.");
+    console.log("ActoKids GET event by event_id function ended.");
     
-    return response;
 }//end of exports.handler

--- a/lambda/events_id/get/package-lock.json
+++ b/lambda/events_id/get/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "get",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+      "is-uuid": {
+        "version": "1.0.2",
+        "resolved": "https://registry.npmjs.org/is-uuid/-/is-uuid-1.0.2.tgz",
+        "integrity": "sha1-rRiY3fFUlHwlyOVJZvSGBOnK7MQ="
+      }
+    }
+  }

--- a/lambda/events_id/get/package.json
+++ b/lambda/events_id/get/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "get",
+    "version": "1.0.0",
+    "main": "index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+      "is-uuid": "^1.0.2"
+    },
+    "description": ""
+  }


### PR DESCRIPTION
Relating to [Issue #54](https://github.com/ActoKids/api/issues/54)

**Testing**: 
Get all events: [https://api.2edusite.com/v1/events](https://api.2edusite.com/v1/events)
Get event by event_id: [https://api.2edusite.com/v1/events/{event_id}](https://api.2edusite.com/v1/events/94fd882e-4680-47fd-b107-320d86b6f7b8)

**Summary of changes**:
- Included necessary files for adding the is-uuid library to GET events by id function. 
- Changed code to work with callbacks instead of the proxy integration for error handling
- Changed table and region to Oregon/Production region 